### PR TITLE
strapi-connector-bookshelf: add database config flag check (config/da…

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/queries.js
+++ b/packages/strapi-connector-bookshelf/lib/queries.js
@@ -11,6 +11,7 @@ const { contentTypes: contentTypesUtils } = require('strapi-utils');
 const { singular } = require('pluralize');
 const { handleDatabaseError } = require('./utils/errors');
 
+const throwDatabaseErrors = _.get(strapi.config, ['database', 'throwDatabaseErrors'], false);
 const { PUBLISHED_AT_ATTRIBUTE } = contentTypesUtils.constants;
 const pickCountFilters = omit(['sort', 'limit', 'start']);
 
@@ -55,7 +56,11 @@ module.exports = function createQueryBuilder({ model, strapi }) {
     try {
       return await fn(...args);
     } catch (error) {
-      return handleDatabaseError(error);
+      if (throwDatabaseErrors !== true) {
+        return handleDatabaseError(error);
+      } else {
+        throw error;
+      }
     }
   };
 


### PR DESCRIPTION
…tabase/throwDatabaseErrors) to ignore duplicate error check on update/create

### What does it do?

database config flag check (config/database/throwDatabaseErrors) to ignore duplicate error check on update/create

### Why is it needed?

change made as part of https://github.com/strapi/strapi/pull/8367 (packages/strapi-connector-bookshelf/lib/utils/errors.js handleDatabaseError function) leaves no possibility to customize or disable duplicate error wrapping.
