### PR TITLE
strapi-connector-bookshelf: changes from [https://github.com/strapi/s…

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/relations.js
+++ b/packages/strapi-connector-bookshelf/lib/relations.js
@@ -221,9 +221,11 @@ module.exports = {
         case 'manyToMany': {
           const storedValue = transformToArrayID(response[current]);
           const currentValue = transformToArrayID(params.values[current]);
+          
+          const isEqual = _.isEqual(currentValue, storedValue);
 
-          const toAdd = _.difference(currentValue, storedValue);
-          const toRemove = _.difference(storedValue, currentValue);
+          const toAdd = isEqual ? [] : currentValue;
+          const toRemove = isEqual ? [] : storedValue;
 
           const collection = this.forge({
             [this.primaryKey]: primaryKeyValue,


### PR DESCRIPTION
…trapi/pull/9702]: preserve many to many order on update

### What does it do?

Preserve many to many order on update for bookshelf

### Why is it needed?

To justify the ability to reorder many to many items in the list

### Related issue(s)/PR(s)

Related to pr: https://github.com/strapi/strapi/pull/9702
